### PR TITLE
HOCS-1076 Use cert-manager.io

### DIFF
--- a/kube/ingress.yaml
+++ b/kube/ingress.yaml
@@ -3,15 +3,15 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   annotations:
+    cert-manager.io/enabled: "true"
     ingress.kubernetes.io/secure-backends: "true"
     ingress.kubernetes.io/backend-protocol: "HTTPS"
     kubernetes.io/ingress.class: nginx-external
-    stable.k8s.psg.io/kcm.provider: http
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: test-viewer-basic-auth
     nginx.ingress.kubernetes.io/auth-realm: "Authentication Required - HOCS"
   labels:
-    stable.k8s.psg.io/kcm.class: default
+    cert-manager.io/solver: http01
   name: hocs-test-viewer
 spec:
   rules:


### PR DESCRIPTION
The Kubernetes configuration prior to this commit used kube-cert-manager
to manage certificates from Let's Encrypt. However, kube-cert-manager is
getting deprecated upstream and will cease working in June 2020.

This commit updates the configuration to use Jetstack's cert-manager,
which is now deployed on the ACP clusters.

The TLS keypair is stored in a secret. In similar commits to this one elsewhere
in the HOCS ecosystem, we rename the secret to prevent multiple certificate
managers managing the same certificate. We don't need to bother here, as
there's no production to worry about.