### PR TITLE
Lower proxy read timeout

### DIFF
--- a/kube/deployment.yaml
+++ b/kube/deployment.yaml
@@ -83,6 +83,9 @@ spec:
               value: /certs/tls.pem
             - name: SERVER_KEY
               value: /certs/tls-key.pem
+            - name: ADD_NGINX_HTTP_CFG
+              value: |
+                proxy_read_timeout 10s;
             - name: ADD_NGINX_SERVER_CFG
               value: 'location = /reload { allow 127.0.0.1; deny all; content_by_lua_block { os.execute("touch /tmp/nginx-reload-triggered; /usr/local/openresty/nginx/sbin/nginx -s reload; touch /tmp/nginx-reload-complete;") } }'
           volumeMounts:


### PR DESCRIPTION
For unidentified reasons some of the CSS in the test reports is timing
out instead of rendering. Because external CSS stylesheets are
render-blocking resources, this problem causes reports to not be
rendered for the full 2 minutes before the .css file times out.

Instead of actually fixing the problem, this commit lowers the timeout
from the default of 2 minutes to just 10 seconds. This means that
reports still take a while to load, but means you don't have to wait too
long.