### PR TITLE
HOCS-2886 Return something on error

### DIFF
--- a/aws-proxy.js
+++ b/aws-proxy.js
@@ -180,7 +180,7 @@ exports = module.exports = {
                     })
                     .catch(err => {
                         console.log("get object", bucketPrefix, err, err.stack);
-                        res.send(err);
+                        res.status(err.statusCode || 500).json(err)
                     });
             } else {
                 fs.access('cache/' + bucketPrefix, (err) => {
@@ -210,6 +210,8 @@ exports = module.exports = {
                                     }
 
                                 });
+                            } else {
+                              res.status(err.statusCode || 500).json(err)
                             }
                         });
                     } else {


### PR DESCRIPTION
If the AWS proxy encountered a problem (like a file not existing in the
bucket), the app previously didn't return anything -- it just held the
connection open until nginx intervened.

This commit makes sure we actually res.send() something even if there
was an error -- here, we send the status code of the resulting error
message and the error as JSON.