### PR TITLE
HOCS-2239: update uptime annotation

### DIFF
--- a/kube/deployment.yaml
+++ b/kube/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: extensions/v1
 kind: Deployment
 metadata:
   annotations:
-    downscaler/uptime: Mon-Fri 08:00-17:30 Europe/London
+    downscaler/uptime: Mon-Fri 08:00-18:00 Europe/London
   name: hocs-test-viewer
   labels:
     version: {{.VERSION}}


### PR DESCRIPTION
Currently the rest of the deployments are scheduled to come up at 
8:00 BST and downscale at 18:00 BST. This change brings this 
deployment in line.